### PR TITLE
Use external gunzip call

### DIFF
--- a/lib/log_counter.rb
+++ b/lib/log_counter.rb
@@ -10,7 +10,7 @@
 require 'csv'
 require_relative 'log_counter'
 require_relative 'log_parser'
-require_relative 'log_streamer'
+require_relative 'log_file_streamer'
 
 class LogCounter
   FIRST_ROW_HEADING = 'Source file size'

--- a/lib/log_counter.rb
+++ b/lib/log_counter.rb
@@ -10,6 +10,7 @@
 require 'csv'
 require_relative 'log_counter'
 require_relative 'log_parser'
+require_relative 'log_streamer'
 
 class LogCounter
   FIRST_ROW_HEADING = 'Source file size'
@@ -101,12 +102,13 @@ file from this directory.
     $logger.info "Counting #{file_path} - #{file_size} bytes"
 
     counts_by_day = Hash.new { |hash, key| hash[key] = Hash.new(0) }
-    parser = LogParser.open(file_path)
-    parser.each do |entry|
-      day = entry[:time].strftime('%Y%m%d')
-      hour = entry[:time].strftime('%H')
-      key = "#{hour} #{entry[:path]} #{entry[:method]} #{entry[:status]} #{entry[:cdn_backend]}"
-      counts_by_day[day][key] += 1
+    LogFileStreamer.open(file_path) do |stream|
+      LogParser.new(stream).each do |entry|
+        day = entry[:time].strftime('%Y%m%d')
+        hour = entry[:time].strftime('%H')
+        key = "#{hour} #{entry[:path]} #{entry[:method]} #{entry[:status]} #{entry[:cdn_backend]}"
+        counts_by_day[day][key] += 1
+      end
     end
 
     counts_by_day

--- a/lib/log_file_streamer.rb
+++ b/lib/log_file_streamer.rb
@@ -1,27 +1,4 @@
-# Stream lines from a log file, handling log rotation.
-
-require 'open3'
-
-class ProcessStreamer
-  def self.open(command)
-    Open3.popen2(*command) do |_stdin, stdout, wait_thr|
-      begin
-        yield stdout
-      rescue
-        wait_thr.kill
-        raise
-      end
-    end
-  end
-end
-
-class LogTailStreamer
-  def self.open(log_file)
-    ProcessStreamer.open(["/usr/bin/tail", "-F", "-n", "0", log_file]) do |stream|
-      yield stream
-    end
-  end
-end
+require_relative 'process_streamer'
 
 class LogFileStreamer
   def initialize(log_file, block)

--- a/lib/log_parser.rb
+++ b/lib/log_parser.rb
@@ -1,6 +1,6 @@
 require 'date'
-require 'zlib'
 require_relative 'config_logging'
+require_relative 'log_streamer'
 
 LogEntry = Struct.new(:ip, :time, :method, :path, :status, :cdn_backend)
 
@@ -9,10 +9,6 @@ class LogParser
 
   def initialize(stream)
     @stream = stream
-  end
-
-  def self.open(file_path)
-    LogParser.new(file_reader(file_path))
   end
 
   def each(&block)
@@ -49,13 +45,5 @@ private
       pieces[11],
       pieces[12],
     )
-  end
-
-  def self.file_reader(file_path)
-    if file_path.end_with?(".gz")
-      Zlib::GzipReader.open(file_path)
-    else
-      File.new(file_path)
-    end
   end
 end

--- a/lib/log_parser.rb
+++ b/lib/log_parser.rb
@@ -1,6 +1,5 @@
 require 'date'
 require_relative 'config_logging'
-require_relative 'log_streamer'
 
 LogEntry = Struct.new(:ip, :time, :method, :path, :status, :cdn_backend)
 

--- a/lib/log_streamer.rb
+++ b/lib/log_streamer.rb
@@ -24,25 +24,34 @@ class LogTailStreamer
 end
 
 class LogFileStreamer
+  def initialize(log_file, block)
+    @log_file = log_file
+    @block = block
+  end
+
   def self.open(log_file, &block)
-    if log_file.end_with?(".gz")
-      stream_gz_file(log_file, block)
+    LogFileStreamer.new(log_file, block).stream
+  end
+
+  def stream
+    if @log_file.end_with?(".gz")
+      stream_gz_file
     else
-      stream_uncompressed_file(log_file, block)
+      stream_uncompressed_file
     end
   end
 
 private
 
-  def self.stream_uncompressed_file(log_file, block)
-    File.open(log_file) do |stream|
-      block.call(stream)
+  def stream_uncompressed_file
+    File.open(@log_file) do |stream|
+      @block.call(stream)
     end
   end
 
-  def self.stream_gz_file(log_file, block)
-    ProcessStreamer.open(["gunzip", "-c", log_file]) do |stream|
-      block.call(stream)
+  def stream_gz_file
+    ProcessStreamer.open(["gunzip", "-c", @log_file]) do |stream|
+      @block.call(stream)
     end
   end
 end

--- a/lib/log_streamer.rb
+++ b/lib/log_streamer.rb
@@ -2,19 +2,47 @@
 
 require 'open3'
 
-class LogStreamer
-  def initialize(log_file)
-    @log_file = log_file
-  end
-
-  def with_stream(&block)
-    Open3.popen2("tail -F -n 0 \"#{@log_file}\"") do |_stdin, stdout, wait_thr|
+class ProcessStreamer
+  def self.open(command)
+    Open3.popen2(*command) do |_stdin, stdout, wait_thr|
       begin
-        block.call(stdout)
+        yield stdout
       rescue
         wait_thr.kill
         raise
       end
+    end
+  end
+end
+
+class LogTailStreamer
+  def self.open(log_file)
+    ProcessStreamer.open(["/usr/bin/tail", "-F", "-n", "0", log_file]) do |stream|
+      yield stream
+    end
+  end
+end
+
+class LogFileStreamer
+  def self.open(log_file, &block)
+    if log_file.end_with?(".gz")
+      stream_gz_file(log_file, block)
+    else
+      stream_uncompressed_file(log_file, block)
+    end
+  end
+
+private
+
+  def self.stream_uncompressed_file(log_file, block)
+    File.open(log_file) do |stream|
+      block.call(stream)
+    end
+  end
+
+  def self.stream_gz_file(log_file, block)
+    ProcessStreamer.open(["gunzip", "-c", log_file]) do |stream|
+      block.call(stream)
     end
   end
 end

--- a/lib/log_tail_streamer.rb
+++ b/lib/log_tail_streamer.rb
@@ -1,0 +1,9 @@
+require_relative 'process_streamer'
+
+class LogTailStreamer
+  def self.open(log_file)
+    ProcessStreamer.open(["/usr/bin/tail", "-F", "-n", "0", log_file]) do |stream|
+      yield stream
+    end
+  end
+end

--- a/lib/process_streamer.rb
+++ b/lib/process_streamer.rb
@@ -1,0 +1,14 @@
+require 'open3'
+
+class ProcessStreamer
+  def self.open(command)
+    Open3.popen2(*command) do |_stdin, stdout, wait_thr|
+      begin
+        yield stdout
+      rescue
+        wait_thr.kill
+        raise
+      end
+    end
+  end
+end

--- a/scripts/monitor_logs.rb
+++ b/scripts/monitor_logs.rb
@@ -6,7 +6,7 @@
 # GOVUK_PROCESSED_DATA_DIR - directory to write proessed log data to
 
 require_relative '../lib/log_monitor'
-require_relative '../lib/log_streamer'
+require_relative '../lib/log_tail_streamer'
 
 log_dir = ENV.fetch("GOVUK_CDN_LOG_DIR", "")
 processed_dir = ENV.fetch("GOVUK_PROCESSED_DATA_DIR", "")

--- a/scripts/monitor_logs.rb
+++ b/scripts/monitor_logs.rb
@@ -20,6 +20,6 @@ end
 
 log_file = "#{log_dir}/cdn-govuk.log"
 monitor = LogMonitor.new(processed_dir)
-LogStreamer.new(log_file).with_stream do |stream|
+LogTailStreamer.open(log_file) do |stream|
   monitor.monitor(stream)
 end

--- a/spec/log_parser_spec.rb
+++ b/spec/log_parser_spec.rb
@@ -5,7 +5,7 @@ describe "Parse logfiles" do
   def parse_log_line(logline)
     logfile = "#{$tempdir}/log"
     write_lines(logfile, [logline])
-    LogParser.open(logfile).to_a
+    LogFileStreamer.open(logfile) { |stream| LogParser.new(stream).to_a }
   end
 
   it "Parses a valid log line" do
@@ -51,7 +51,7 @@ describe "Parse logfiles" do
     # zlib implementation we use handles that format correctly.
     `gzip "#{logfile}"`
 
-    entries = LogParser.open("#{logfile}.gz").to_a
+    entries = LogFileStreamer.open("#{logfile}.gz") { |stream| LogParser.new(stream).to_a }
     expect(entries.size).to eq(1)
     expect(entries[0].ip).to eq('1.1.1.1')
   end


### PR DESCRIPTION
Ruby's internal GzipReader appears to be incapable of processing large
files without buffering the whole output in memory.  Therefore, use an
external call to `gunzip` instead.

In order to do this, we use the same LogStreamer code which we're
already using to stream output from an external process:

 - we rename the existing LogStreamer class to LogTailStreamer, which is
   a more descriptive name (it only tails the end of the log file,
   ignoring existing bits of the file).

 - we refactor the implementation of LogTailStreamer to separate out the
   definition of the process it calls, and abstract streaming the output
   of the process to a ProcessStreamer class.

 - we replace the LogParser::file_reader class method with a
   LogFileStreamer class

To ensure the `gunzip` process is cleaned up properly, LogFileStreamer
takes a block and calls it with the stream from `gunzip`.  This means we
can't continue to support the `LogParser.open` method with the same
semantics (returning a parser with an open stream), and this is a bit
non standard anyway, so we just remove it and call it explicitly.