### PR TITLE
Use external count tools, and compress count files

### DIFF
--- a/lib/log_counter.rb
+++ b/lib/log_counter.rb
@@ -136,7 +136,9 @@ file from this directory.
 
   def sort_file
     $logger.info "Sorting #{temp_parsed_file}"
-    system({"LC_ALL" => "C"}, "sort", "-o", temp_sorted_file, temp_parsed_file)
+    unless system({"LC_ALL" => "C"}, "sort", "-o", temp_sorted_file, temp_parsed_file)
+      raise "Failed to sort #{temp_parsed_file}"
+    end
   end
 
   class ItemCounter
@@ -188,7 +190,9 @@ file from this directory.
     def finish_output_file
       unless @csv_writer.nil?
         @csv_writer.close
-        system({"LC_ALL" => "C"}, "gzip", @temp_output_file)
+        unless system({"LC_ALL" => "C"}, "gzip", @temp_output_file)
+          raise "Failed to gzip #{@temp_output_file}"
+        end
         File.rename("#{@temp_output_file}.gz", @output_file)
       end
     end

--- a/lib/log_counter.rb
+++ b/lib/log_counter.rb
@@ -136,7 +136,7 @@ file from this directory.
 
   def sort_file
     $logger.info "Sorting #{temp_parsed_file}"
-    ProcessStreamer.open(["sort", "-o", temp_sorted_file, temp_parsed_file]) do |stream| end
+    system({"LC_ALL" => "C"}, "sort", "-o", temp_sorted_file, temp_parsed_file)
   end
 
   class ItemCounter
@@ -176,7 +176,7 @@ file from this directory.
     def start_output_file(day)
       output_dir = "#{daily_dir}/#{day}"
       FileUtils::mkdir_p output_dir
-      @output_file = "#{output_dir}/count_#{base_name}.csv"
+      @output_file = "#{output_dir}/count_#{base_name}.csv.gz"
       @temp_output_file = "#{output_dir}/tmp_#{base_name}.tmp"
       if File.exist?(@temp_output_file)
         File.delete(@temp_output_file)
@@ -188,7 +188,8 @@ file from this directory.
     def finish_output_file
       unless @csv_writer.nil?
         @csv_writer.close
-        File.rename(@temp_output_file, @output_file)
+        system({"LC_ALL" => "C"}, "gzip", @temp_output_file)
+        File.rename("#{@temp_output_file}.gz", @output_file)
       end
     end
   end

--- a/lib/log_counter.rb
+++ b/lib/log_counter.rb
@@ -205,19 +205,4 @@ file from this directory.
       Dir.mkdir dir
     end
   end
-
-  def filter_counts(counts)
-    counts.reject { |key, count|
-      path = key.split[3]
-      # Reject some paths which might contain personal information, if they've
-      # not been accessed frequently:
-      #  - smart answer paths include a /y/ section before the answers to
-      #  questions.
-      #  - things like searches contain query strings
-      #
-      count < 10 && (
-        path.include?("/y/") || path.include("?")
-      )
-    }
-  end
 end

--- a/lib/log_counter.rb
+++ b/lib/log_counter.rb
@@ -17,9 +17,12 @@ class LogCounter
   attr_reader :file_path
   attr_reader :counts_dir
   attr_reader :base_name
+  attr_reader :work_dir
   attr_reader :daily_dir
   attr_reader :counted_dir
   attr_reader :counted_file
+  attr_reader :temp_parsed_file
+  attr_reader :temp_sorted_file
   attr_reader :file_size
 
   def initialize(file_path, counts_dir)
@@ -28,12 +31,16 @@ class LogCounter
 
     @base_name = File.basename(file_path).gsub(/.gz$/, '')
 
+    @work_dir = "#{counts_dir}/tmp"
     @daily_dir = "#{counts_dir}/daily"
 
     # This file is used to mark that a log has been counted.  The length of the
     # log file is written into it.
     @counted_dir = "#{counts_dir}/counted"
     @counted_file = "#{counted_dir}/counted_#{base_name}"
+
+    @temp_parsed_file = "#{work_dir}/tmp_parsed_#{base_name}.tmp"
+    @temp_sorted_file = "#{work_dir}/tmp_sorted_#{base_name}.tmp"
 
     # Fetch this explicitly at the start.  This ensures that if the file is
     # still being written to, the size stored in the output file will differ
@@ -48,10 +55,15 @@ class LogCounter
       return
     end
 
-    counts_by_day = process_file
-    write_counts(counts_by_day)
-    write_counted_file
-    $logger.info "Counts written"
+    begin
+      parse_file
+      sort_file
+      count_file
+      write_counted_file
+      $logger.info "Counts written"
+    ensure
+      remove_temp_files
+    end
   end
 
 private
@@ -60,6 +72,7 @@ private
     ensure_directory_exists counts_dir
     ensure_directory_exists daily_dir
     ensure_directory_exists counted_dir
+    ensure_directory_exists work_dir
 
     unless File.exist? "#{counted_dir}/README"
       File.open("#{counted_dir}/README", "wb") do |file|
@@ -75,6 +88,15 @@ To trigger re-processing of a particular log file, remove the corresponding
 file from this directory.
 }
       end
+    end
+  end
+
+  def remove_temp_files
+    if File.exist?(temp_parsed_file)
+      File.unlink(temp_parsed_file)
+    end
+    if File.exist?(temp_sorted_file)
+      File.unlink(temp_sorted_file)
     end
   end
 
@@ -98,55 +120,64 @@ file from this directory.
     end
   end
 
-  def process_file
+  def parse_file
     $logger.info "Counting #{file_path} - #{file_size} bytes"
 
-    counts_by_day = Hash.new { |hash, key| hash[key] = Hash.new(0) }
-    LogFileStreamer.open(file_path) do |stream|
-      LogParser.new(stream).each do |entry|
-        day = entry[:time].strftime('%Y%m%d')
-        hour = entry[:time].strftime('%H')
-        key = "#{hour} #{entry[:path]} #{entry[:method]} #{entry[:status]} #{entry[:cdn_backend]}"
-        counts_by_day[day][key] += 1
+    File.open(temp_parsed_file, "wb") do |out_fd|
+      LogFileStreamer.open(file_path) do |stream|
+        LogParser.new(stream).each do |entry|
+          day = entry[:time].strftime('%Y%m%d')
+          hour = entry[:time].strftime('%H')
+          out_fd.write("#{day} #{hour} #{entry[:path]} #{entry[:method]} #{entry[:status]} #{entry[:cdn_backend]}\n")
+        end
       end
     end
-
-    counts_by_day
   end
 
-  def write_counts(counts_by_day)
-    $logger.info "Writing counts"
+  def sort_file
+    ProcessStreamer.open(["sort", "-o", temp_sorted_file, temp_parsed_file]) do |stream| end
+  end
 
-    counts_by_day.sort.each do |day, counts|
-      output_dir = "#{daily_dir}/#{day}"
-      ensure_directory_exists(output_dir)
+  def count_file
+    ProcessStreamer.open(["uniq", "-c", temp_sorted_file]) do |stream|
+      last_day = nil
+      output_file = nil
+      csv_writer = nil
+      temp_output_file = nil
 
-      # Write to a temporary file, and then rename, to avoid partially written
-      # files ever matching the pattern "count_*", and to ensure that failures
-      # will be retried.
-      temp_file = "#{output_dir}/tmp_#{base_name}.tmp"
-      write_counts_for_day(counts, temp_file)
+      stream.each_line do |line|
+        line = line.strip
+        count, day, data = line.strip.split(/ /, 3)
 
-      output_file = "#{output_dir}/count_#{base_name}.csv"
-      File.rename(temp_file, output_file)
+        if day != last_day
+          output_dir = "#{daily_dir}/#{day}"
+          ensure_directory_exists(output_dir)
+          unless csv_writer.nil?
+            csv_writer.close
+            File.rename(temp_output_file, output_file)
+          end
+          output_file = "#{output_dir}/count_#{base_name}.csv"
+          $logger.info "Writing counts for #{output_file}"
+          temp_output_file = "#{output_dir}/tmp_#{base_name}.tmp"
+          if File.exist?(temp_output_file)
+            File.delete(temp_output_file)
+          end
+          csv_writer = CSV.open(temp_output_file, "wb", encoding: 'UTF-8')
+        end
+        last_day = day
+
+        csv_writer << [data, count]
+      end
+      unless csv_writer.nil?
+        csv_writer.close
+        File.rename(temp_output_file, output_file)
+      end
     end
   end
 
   def ensure_directory_exists(dir)
     unless File.exist? dir
       Dir.mkdir dir
-    end
-  end
-
-  def write_counts_for_day(counts, dest_file)
-    if File.exist?(dest_file)
-      File.delete(dest_file)
-    end
-
-    CSV.open(dest_file, 'wb', encoding: 'UTF-8') do |csv|
-      counts.sort.each do |key, count|
-        csv << [key, count]
-      end
     end
   end
 

--- a/lib/process_streamer.rb
+++ b/lib/process_streamer.rb
@@ -2,7 +2,7 @@ require 'open3'
 
 class ProcessStreamer
   def self.open(command)
-    Open3.popen2(*command) do |_stdin, stdout, wait_thr|
+    Open3.popen2({"LC_ALL" => "C"}, *command) do |_stdin, stdout, wait_thr|
       begin
         yield stdout
       rescue

--- a/lib/process_streamer.rb
+++ b/lib/process_streamer.rb
@@ -4,7 +4,12 @@ class ProcessStreamer
   def self.open(command)
     Open3.popen2({"LC_ALL" => "C"}, *command) do |_stdin, stdout, wait_thr|
       begin
-        yield stdout
+        result = yield stdout
+        exit_status = wait_thr.value
+        unless exit_status
+          raise "Command #{command} failed with exit status #{exit_status}"
+        end
+        result
       rescue
         wait_thr.kill
         raise

--- a/lib/successful_access_calculator.rb
+++ b/lib/successful_access_calculator.rb
@@ -82,13 +82,15 @@ private
 
   def count_successes_for_day(day_dir)
     success_counts = Hash.new(0)
-    Dir["#{day_dir}/count_*.csv"].sort.each do |file_path|
+    Dir["#{day_dir}/count_*.csv.gz"].sort.each do |file_path|
       $logger.info "Processing counts from #{file_path}"
-      CSV.foreach(file_path, 'r') do |row|
-        _hour, path, method, status, _cdn_origin = row[0].split(' ')
-        count = row[1].to_i
-        if status.match(/^[23][0-9][0-9]$/) && method == 'GET'
-          success_counts[path] += count
+      ProcessStreamer.open(["gunzip", "-c", file_path]) do |stream|
+        CSV.new(stream).each do |row|
+          _hour, path, method, status, _cdn_origin = row[0].split(' ')
+          count = row[1].to_i
+          if status.match(/^[23][0-9][0-9]$/) && method == 'GET'
+            success_counts[path] += count
+          end
         end
       end
     end

--- a/spec/count_cdn_logs_spec.rb
+++ b/spec/count_cdn_logs_spec.rb
@@ -11,7 +11,7 @@ describe "Counting CDN logs" do
     expect(recorded_stderr).to match("cdn-govuk.log-20150823")
     expect(recorded_stderr).to match("cdn-govuk.log-20150829")
 
-    count_file_for_29th = "#{$tempdir}/raw_counts/daily/20150829/count_cdn-govuk.log-20150829.csv"
+    count_file_for_29th = "#{$tempdir}/raw_counts/daily/20150829/count_cdn-govuk.log-20150829.csv.gz"
     expect(read_lines(count_file_for_29th)).to eq([
       '05 /a-url GET 200 origin,1',
       '05 /a-url-with-unicode-€ GET 200 origin,1',

--- a/spec/log_counter_spec.rb
+++ b/spec/log_counter_spec.rb
@@ -10,10 +10,6 @@ describe "Count logfiles" do
     [counts_dir, recorded_stderr]
   end
 
-  def read_counts(count_file)
-    File.readlines(count_file).map(&:strip)
-  end
-
   it "Counts a sample log file" do
     logfile = "#{$tempdir}/log"
     write_lines(logfile, [
@@ -25,12 +21,12 @@ describe "Count logfiles" do
     ])
 
     counts_dir, _stderr = count_log(logfile)
-    expect(read_counts("#{counts_dir}/daily/20150821/count_log.csv")).to eq([
+    expect(read_lines("#{counts_dir}/daily/20150821/count_log.csv.gz")).to eq([
       "05 /a-url GET 200 origin,2",
       "05 /another-url GET 200 origin,1",
       "06 /a-url GET 200 origin,1",
     ])
-    expect(read_counts("#{counts_dir}/daily/20150822/count_log.csv")).to eq([
+    expect(read_lines("#{counts_dir}/daily/20150822/count_log.csv.gz")).to eq([
       "05 /a-url GET 200 origin,1",
     ])
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,14 +54,26 @@ def write_lines(file_name, lines)
   unless File.exist?(dir)
     FileUtils::mkdir_p dir
   end
-  File.open(file_name, "ab") do |fd|
+  if file_name.end_with? '.gz'
+    unzipped_name = file_name.sub(/.gz$/, '')
+  else
+    unzipped_name = file_name
+  end
+  File.open(unzipped_name, "ab") do |fd|
     lines.each do |line|
       fd.write line
       fd.write "\n"
     end
   end
+  if file_name.end_with? '.gz'
+    `gzip "#{unzipped_name}"`
+  end
 end
 
 def read_lines(file_name)
-  File.readlines(file_name).map(&:rstrip)
+  if file_name.end_with?('.gz')
+    `gunzip -c "#{file_name}"`.split("\n").map(&:rstrip)
+  else
+    File.readlines(file_name).map(&:rstrip)
+  end
 end

--- a/spec/successful_access_calculator_spec.rb
+++ b/spec/successful_access_calculator_spec.rb
@@ -15,7 +15,7 @@ describe "Finding successful accesses" do
   end
 
   it "Finds the 2xx and 3xx accesses" do
-    write_lines("#{counts_dir}/#{default_day}/count_1.csv", [
+    write_lines("#{counts_dir}/#{default_day}/count_1.csv.gz", [
       '05 /a-200-url GET 200 origin,1',
       '05 /a-201-url GET 201 origin,1',
       '05 /a-301-url GET 301 origin,1',
@@ -36,7 +36,7 @@ describe "Finding successful accesses" do
 
 
   it "Filters out smartanswers which visited fewer than 10 times in a day" do
-    write_lines("#{counts_dir}/#{default_day}/count_1.csv", [
+    write_lines("#{counts_dir}/#{default_day}/count_1.csv.gz", [
       '05 /smartanswer/y/count-9 GET 200 origin,9',
       '05 /smartanswer/y/count-10 GET 200 origin,10',
     ])
@@ -51,7 +51,7 @@ describe "Finding successful accesses" do
   end
 
   it "Filters out urls with query strings visited fewer than 10 times in a day" do
-    write_lines("#{counts_dir}/#{default_day}/count_1.csv", [
+    write_lines("#{counts_dir}/#{default_day}/count_1.csv.gz", [
       '05 /search?q=unusual GET 200 origin,9',
       '05 /search?q=tax GET 200 origin,10',
     ])
@@ -66,7 +66,7 @@ describe "Finding successful accesses" do
   end
 
   it "Adds up counts from separate hours in a day" do
-    write_lines("#{counts_dir}/#{default_day}/count_1.csv", [
+    write_lines("#{counts_dir}/#{default_day}/count_1.csv.gz", [
       '05 /smartanswer/y/count-5 GET 200 origin,5',
       '06 /smartanswer/y/count-5 GET 200 origin,5',
     ])
@@ -82,10 +82,10 @@ describe "Finding successful accesses" do
   end
 
   it "Adds up counts from separate count files in a day" do
-    write_lines("#{counts_dir}/#{default_day}/count_1.csv", [
+    write_lines("#{counts_dir}/#{default_day}/count_1.csv.gz", [
       '05 /smartanswer/y/count GET 200 origin,5',
     ])
-    write_lines("#{counts_dir}/#{default_day}/count_2.csv", [
+    write_lines("#{counts_dir}/#{default_day}/count_2.csv.gz", [
       '06 /smartanswer/y/count GET 200 origin,7',
     ])
 
@@ -101,10 +101,10 @@ describe "Finding successful accesses" do
   end
 
   it "Doesn't add up counts from separate days" do
-    write_lines("#{counts_dir}/#{default_day}/count_1.csv", [
+    write_lines("#{counts_dir}/#{default_day}/count_1.csv.gz", [
       '05 /smartanswer/y/count GET 200 origin,5',
     ])
-    write_lines("#{counts_dir}/20150822/count_2.csv", [
+    write_lines("#{counts_dir}/20150822/count_2.csv.gz", [
       '06 /smartanswer/y/count GET 200 origin,7',
     ])
 


### PR DESCRIPTION
Counting a day's accesses in memory was using well over 1Gb of memory,
and getting very slow as a result.  Instead, use the UNIX sort command
to sort the accesses into order, then use `uniq -c` to count the
accesses.  These tools are already optimised to work with large files.
I've tested this on some large datasets, processing them in a few
minutes.

The count files produced by this are actually pretty big, and rarely read, so it's worth
compressing them to save a lot of disk space and IO.