### PR TITLE
Don't consider 3xx status codes to be "good"

### DIFF
--- a/lib/successful_access_calculator.rb
+++ b/lib/successful_access_calculator.rb
@@ -88,7 +88,7 @@ private
         CSV.new(stream).each do |row|
           _hour, path, method, status, _cdn_origin = row[0].split(' ')
           count = row[1].to_i
-          if status.match(/^[23][0-9][0-9]$/) && method == 'GET'
+          if status.match(/^2[0-9][0-9]$/) && method == 'GET'
             success_counts[path] += count
           end
         end

--- a/spec/successful_access_calculator_spec.rb
+++ b/spec/successful_access_calculator_spec.rb
@@ -14,7 +14,7 @@ describe "Finding successful accesses" do
     "20150821"
   end
 
-  it "Finds the 2xx and 3xx accesses" do
+  it "Finds the 2xx accesses" do
     write_lines("#{counts_dir}/#{default_day}/count_1.csv.gz", [
       '05 /a-200-url GET 200 origin,1',
       '05 /a-201-url GET 201 origin,1',
@@ -30,7 +30,6 @@ describe "Finding successful accesses" do
     expect(read_lines("#{daily_successes_dir}/successes_#{default_day}")).to eq([
       "/a-200-url #{default_day}",
       "/a-201-url #{default_day}",
-      "/a-301-url #{default_day}",
     ])
   end
 


### PR DESCRIPTION
When calculating lists of urls which return successful status codes,
we're getting a very large number of urls which are redirects.  Some
of these redirects are even to other urls which then return a 404 (eg,
stripping a trailing slash from the URL).

To reduce the volume of URLs returned, don't consider 3xx status codes
as "good".