### PR TITLE
Fix bug in sorting of first-last-success file

### DIFF
--- a/lib/first_last_success_calculator.rb
+++ b/lib/first_last_success_calculator.rb
@@ -105,7 +105,7 @@ private
     $logger.info "Calculating first and last access times from:\n - #{source_files.join "\n - "}"
     temp_first_last_file = "#{first_last_file}.tmp"
     File.open(temp_first_last_file, "wb") do |output_file|
-      Open3.popen2("sort --files0-from=-") do |stdin, stdout, wait_thr|
+      Open3.popen2({"LC_ALL" => "C"}, "sort --files0-from=-") do |stdin, stdout, wait_thr|
         stdin.write(source_files.join("\0"))
         stdin.close
 

--- a/spec/first_last_success_calculator_spec.rb
+++ b/spec/first_last_success_calculator_spec.rb
@@ -62,4 +62,23 @@ describe "Finding the first and last sucessful accesses" do
     expect(recorded_stderr).to match("#{daily_successes_dir}/successes_20150822")
     expect(recorded_stderr).to match("#{daily_successes_dir}/successes_20150828")
   end
+
+  it "uses bytewise sorting" do
+    write_lines("#{daily_successes_dir}/successes_20150821", [
+      "/a-url 20150821",
+      "//a-url 20150821",
+      "/a-url 20150822",
+      "//a-url 20150822",
+    ])
+
+    record_stderr
+    FirstLastSuccessCalculator.new($tempdir).process
+
+    expect(first_last).to eq([
+      "//a-url 20150821",
+      "//a-url 20150822",
+      "/a-url 20150821",
+      "/a-url 20150822",
+    ])
+  end
 end


### PR DESCRIPTION
The sort command for creating the "first-last-success" file was
incorrectly using the system locale, rather than setting the C locale.
This meant that URLs such as `/a-url` and `//a-url` were being compared
as equal, and thus each URL wasn't being grouped together appropriately.

This means that the known-good URLs file has lots of missing entries.
It also makes the sort command significantly slower (because it has to
perform a much more complicated comparison than simple byte-wise
comparison).

After this is deployed, the generated "first-last-successes" file needs
to be deleted, so that the next run will generate it correctly from
scratch.