### PR TITLE
Record log items which fell back from CDN origin

### DIFF
--- a/lib/log_monitor.rb
+++ b/lib/log_monitor.rb
@@ -64,11 +64,19 @@ private
   end
 
   def known_good_fail?(log_entry)
-    log_entry.status !~ /^[123]..$/ and @known_good_urls.include?(log_entry.path)
+    status_code_is_failure?(log_entry) && path_is_known_good?(log_entry)
+  end
+
+  def status_code_is_failure?(log_entry)
+    log_entry.status !~ /^[123][0-9][0-9]$/
+  end
+
+  def path_is_known_good?(log_entry)
+    @known_good_urls.include?(log_entry.path)
   end
 
   def cdn_fall_back?(log_entry)
-    !(log_entry.cdn_backend.nil? || ["", "origin"].include?(log_entry.cdn_backend))
+    ! [nil, "", "origin"].include?(log_entry.cdn_backend)
   end
 
   def recheck_due

--- a/lib/logstash_sender.rb
+++ b/lib/logstash_sender.rb
@@ -7,7 +7,7 @@ class LogstashSender
   end
 
 private
-  def logstash_format_json(logline, type)
+  def logstash_format_json(logline, tags)
     uri = URI.parse(logline.path)
     JSON.generate({
       "@fields" => {
@@ -17,8 +17,9 @@ private
         "status" => logline.status.to_i,
         "remote_addr" => logline[0],
         "request" => "#{logline.method} #{logline.path}",
+        "cdn_backend" => logline.cdn_backend,
         "length" => "-"},
-        "@tags" => [type],
+        "@tags" => tags,
         "@timestamp" => logline.time.iso8601,
         "@version" => "1"
     })


### PR DESCRIPTION
Send a logstash message for every log item where the CDN backend information is
present but the request wasn't served by "origin".