### PR TITLE
Only log known-good failures for GET requests

### DIFF
--- a/lib/log_monitor.rb
+++ b/lib/log_monitor.rb
@@ -64,6 +64,11 @@ private
   end
 
   def known_good_fail?(log_entry)
+    unless log_entry.method == "GET"
+      # Our list of known good urls is only for GET requests, so ignore any
+      # non-GET requests for this monitoring.
+      return false
+    end
     status_code_is_failure?(log_entry) && path_is_known_good?(log_entry)
   end
 


### PR DESCRIPTION
The list of "known good" URLs is generated from GET requests.
Therefore, it will often be an error if a request using another method
(such as POST or OPTIONS) is made to these URLs.

We want the "known good" failure list to be noise free, so that we can
trust that entries in it are things that we should be alerting on.
Therefore, we'll ignore log entries that aren't from GET requests when
checking for known good failures.