### PR TITLE
Log time of the last successful access in Kibana

### DIFF
--- a/lib/known_good_calculator.rb
+++ b/lib/known_good_calculator.rb
@@ -61,7 +61,7 @@ private
           last_date = Date.iso8601(last_day)
           elapsed_days = (last_date - first_date).to_i
           if elapsed_days >= REQUIRED_SEPARATION_DAYS
-            outfd.write "#{path}\n"
+            outfd.write "#{path} #{last_day}\n"
           end
         end
       end

--- a/lib/logstash_sender.rb
+++ b/lib/logstash_sender.rb
@@ -2,12 +2,12 @@ require 'uri'
 require 'json'
 
 class LogstashSender
-  def log(logline, type)
-    $stdout.puts logstash_format_json(logline, type)
+  def log(logline, tags, last_success)
+    $stdout.puts logstash_format_json(logline, tags, last_success)
   end
 
 private
-  def logstash_format_json(logline, tags)
+  def logstash_format_json(logline, tags, last_success)
     uri = URI.parse(logline.path)
     JSON.generate({
       "@fields" => {
@@ -18,10 +18,11 @@ private
         "remote_addr" => logline[0],
         "request" => "#{logline.method} #{logline.path}",
         "cdn_backend" => logline.cdn_backend,
-        "length" => "-"},
-        "@tags" => tags,
-        "@timestamp" => logline.time.iso8601,
-        "@version" => "1"
+        "last_success" => last_success
+      },
+      "@tags" => tags,
+      "@timestamp" => logline.time.iso8601,
+      "@version" => "1"
     })
   end
 end

--- a/spec/known_good_calculator_spec.rb
+++ b/spec/known_good_calculator_spec.rb
@@ -20,7 +20,7 @@ describe "Calculating a list of known good accesses" do
     KnownGoodCalculator.new($tempdir).process
 
     expect(read_lines(known_good_urls_file)).to eq([
-      '/a-url',
+      '/a-url 20150101',
     ])
     expect(recorded_stderr).to match("Calculating known good urls")
   end

--- a/spec/log_monitor_spec.rb
+++ b/spec/log_monitor_spec.rb
@@ -12,7 +12,6 @@ describe "Monitoring incoming logs" do
     })
   end
 
-
   def expect_statsd_increments(monitor, items)
     statsd_sender_double = instance_double("StatsdSender")
     items.each do |item|
@@ -21,8 +20,32 @@ describe "Monitoring incoming logs" do
     allow(monitor).to receive(:statsd_sender).and_return(statsd_sender_double)
   end
 
-  it "Sends output about successful accesses to known urls" do
+  it "Handles a known_good file without dates" do
+    # Handle dates missing from the known_good file for a smooth transition to
+    # adding them.  Can remove this support after deploy and regneration of the
+    # file.
     write_known_good(["/a-url"])
+    write_log(["/a-url 500"])
+
+    monitor = LogMonitor.new($tempdir)
+    expect_statsd_increments(monitor, [
+      "status.500",
+      "cdn_backend.origin",
+      "known_good_fail.status_500",
+    ])
+
+    record_stderr
+    record_stdout
+    monitor.monitor(File.open("#{$tempdir}/log"))
+
+    expect(recorded_stderr).to match("Working with 1 known good urls")
+    expect(recorded_stdout).to eq(
+      %{{"@fields":{"method":"GET","path":"/a-url","query_string":null,"status":500,"remote_addr":"1.1.1.1","request":"GET /a-url","cdn_backend":"origin","last_success":"2014-01-01T00:00:00+00:00"},"@tags":["known_good_fail"],"@timestamp":"2015-08-29T05:57:21+00:00","@version":"1"}\n}
+    )
+  end
+
+  it "Sends output about successful accesses to known urls" do
+    write_known_good(["/a-url 20150801"])
     write_log(["/a-url 200"])
 
     monitor = LogMonitor.new($tempdir)
@@ -40,7 +63,7 @@ describe "Monitoring incoming logs" do
   end
 
   it "Sends output about unsuccessful GET accesses to known urls" do
-    write_known_good(["/a-url"])
+    write_known_good(["/a-url 20150801"])
     write_log(["/a-url 500"])
 
     monitor = LogMonitor.new($tempdir)
@@ -56,12 +79,12 @@ describe "Monitoring incoming logs" do
 
     expect(recorded_stderr).to match("Working with 1 known good urls")
     expect(recorded_stdout).to eq(
-      %{{"@fields":{"method":"GET","path":"/a-url","query_string":null,"status":500,"remote_addr":"1.1.1.1","request":"GET /a-url","cdn_backend":"origin","length":"-"},"@tags":["known_good_fail"],"@timestamp":"2015-08-29T05:57:21+00:00","@version":"1"}\n}
+      %{{"@fields":{"method":"GET","path":"/a-url","query_string":null,"status":500,"remote_addr":"1.1.1.1","request":"GET /a-url","cdn_backend":"origin","last_success":"2015-08-01T00:00:00+00:00"},"@tags":["known_good_fail"],"@timestamp":"2015-08-29T05:57:21+00:00","@version":"1"}\n}
     )
   end
 
   it "Doesn't send output about unsuccessful POST accesses to known urls" do
-    write_known_good(["/a-url"])
+    write_known_good(["/a-url 20150801"])
     write_log(["/a-url 500"], "origin", "POST")
 
     monitor = LogMonitor.new($tempdir)
@@ -79,7 +102,7 @@ describe "Monitoring incoming logs" do
   end
 
   it "Sends output about successful accesses to unknown urls" do
-    write_known_good(["/a-url"])
+    write_known_good(["/a-url 20150801"])
     write_log(["/an-unknown-url 200"])
 
     monitor = LogMonitor.new($tempdir)
@@ -97,7 +120,7 @@ describe "Monitoring incoming logs" do
   end
 
   it "Sends output about unsuccessful accesses to unknown urls" do
-    write_known_good(["/a-url"])
+    write_known_good(["/a-url 20150801"])
     write_log(["/an-unknown-url 500"])
 
     monitor = LogMonitor.new($tempdir)
@@ -115,7 +138,7 @@ describe "Monitoring incoming logs" do
   end
 
   it "Sends the query string in logstash monitoring" do
-    write_known_good(["/a-url?foo"])
+    write_known_good(["/a-url?foo 20150801"])
     write_log(["/a-url?foo 401"])
 
     monitor = LogMonitor.new($tempdir)
@@ -131,11 +154,11 @@ describe "Monitoring incoming logs" do
 
     expect(recorded_stderr).to match("Working with 1 known good urls")
     expect(recorded_stdout).to eq(
-      %{{"@fields":{"method":"GET","path":"/a-url","query_string":"foo","status":401,"remote_addr":"1.1.1.1","request":"GET /a-url?foo","cdn_backend":"origin","length":"-"},"@tags":["known_good_fail"],"@timestamp":"2015-08-29T05:57:21+00:00","@version":"1"}\n})
+      %{{"@fields":{"method":"GET","path":"/a-url","query_string":"foo","status":401,"remote_addr":"1.1.1.1","request":"GET /a-url?foo","cdn_backend":"origin","last_success":"2015-08-01T00:00:00+00:00"},"@tags":["known_good_fail"],"@timestamp":"2015-08-29T05:57:21+00:00","@version":"1"}\n})
   end
 
   it "Sends output about accesses which aren't served by origin" do
-    write_known_good(["/a-url"])
+    write_known_good(["/a-url 20150801"])
     write_log(["/a-url 200"], "mirror1")
 
     monitor = LogMonitor.new($tempdir)
@@ -150,6 +173,28 @@ describe "Monitoring incoming logs" do
 
     expect(recorded_stderr).to match("Working with 1 known good urls")
     expect(recorded_stdout).to eq(
-      %{{"@fields":{"method":"GET","path":"/a-url","query_string":null,"status":200,"remote_addr":"1.1.1.1","request":"GET /a-url","cdn_backend":"mirror1","length":"-"},"@tags":["cdn_fallback"],"@timestamp":"2015-08-29T05:57:21+00:00","@version":"1"}\n})
+      %{{"@fields":{"method":"GET","path":"/a-url","query_string":null,"status":200,"remote_addr":"1.1.1.1","request":"GET /a-url","cdn_backend":"mirror1","last_success":"2015-08-01T00:00:00+00:00"},"@tags":["cdn_fallback"],"@timestamp":"2015-08-29T05:57:21+00:00","@version":"1"}\n})
+  end
+
+  it "Sends extra tags for failed accesses which worked recently" do
+    write_known_good(["/a-url 20150827"])
+    write_log(["/a-url 500"])
+
+    monitor = LogMonitor.new($tempdir)
+    expect_statsd_increments(monitor, [
+      "status.500",
+      "cdn_backend.origin",
+      "known_good_fail.status_500",
+      "recent_known_good_fail.status_500",
+    ])
+
+    record_stderr
+    record_stdout
+    monitor.monitor(File.open("#{$tempdir}/log"))
+
+    expect(recorded_stderr).to match("Working with 1 known good urls")
+    expect(recorded_stdout).to eq(
+      %{{"@fields":{"method":"GET","path":"/a-url","query_string":null,"status":500,"remote_addr":"1.1.1.1","request":"GET /a-url","cdn_backend":"origin","last_success":"2015-08-27T00:00:00+00:00"},"@tags":["known_good_fail","recent_known_good_fail"],"@timestamp":"2015-08-29T05:57:21+00:00","@version":"1"}\n}
+    )
   end
 end


### PR DESCRIPTION
We want to record the time of the last successful access in Kibana, so
that we can generate a report of URLs which have recently started to
fail (separating this of URL which have frequently failed), and also to
emit to statsd information on the number of URLs which have recently
started failing.

This commit adds the date of the last successful access to each line in
the list of known_good URLs.

It then reads that date in when parsing the file, and stores the list of
known_good URLs in a hash instead of an array, associating the date to
the URL.

It uses this data to add an extra field to the logstash output recording
the date when the URL last worked (this should help to identify changes
which caused URLs to stop working) and adds a tag of
"recent_known_good_fail" to such logstash messages.

It also emits separate statsd output for failures of URLs which have had
a successful request in the last 7 days.

This also stops sending a dummy "length" field with a value of "-" to
logstash; this data isn't available, but it's fine to omit it.