### PR TITLE
Only raise an error if we don't have enough pieces

### DIFF
--- a/lib/log_parser.rb
+++ b/lib/log_parser.rb
@@ -32,8 +32,8 @@ private
 
   def parse_line(line)
     pieces = line.split
-    if pieces.size < 12 || pieces.size > 13
-      raise ArgumentError.new("incorrect number of pieces")
+    if pieces.size < 12
+      raise ArgumentError.new("Less log line elements than we expect")
     end
     datetime = DateTime.parse(pieces.slice(3..8).join(' ')).new_offset
     LogEntry.new(

--- a/spec/log_parser_spec.rb
+++ b/spec/log_parser_spec.rb
@@ -73,6 +73,6 @@ describe "Parse logfiles" do
     )
 
     expect(entries.size).to eq(0)
-    expect(recorded_stderr).to match("Invalid log line: incorrect number of pieces")
+    expect(recorded_stderr).to match("Invalid log line: Less log line elements than we expect")
   end
 end


### PR DESCRIPTION
For debug purposes we sometimes add extra info to the end of our CDN log
lines. This doesn't affect the parsing of the log lines so we don't need
to raise an error if we have more pieces than we expect.