### PR TITLE
Update readme for project archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CDN log monitor
 
+**This project is archived and no longer run on GOV.UK as per [RFC-93](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-093-retire-govuk-cdn-logs-monitor.md)** 
+
 Monitor the Content Delivery Network (CDN) logs for GOV.UK to find problems
 with the site.  In particular, look for cases where a URL which has been
 returning a success status changes to returning an error status.


### PR DESCRIPTION
This updates the readme to state that the project is archived. The data that this project generated has been stored on S3 in the govuk-production-cdn-logs-monitor-archive bucket.

Following this being merged I'll archive the repo.